### PR TITLE
safe_str_cmp deprecation

### DIFF
--- a/guides/Flask-JWT Configuration Tutorial.md
+++ b/guides/Flask-JWT Configuration Tutorial.md
@@ -26,12 +26,12 @@ jwt = JWT(app, authenticate, identity)  # /auth
 And in our security.py file, we should have something like this:
 
 ```python
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from models.user import UserModel
 
 def authenticate(username, password):
     user = UserModel.find_by_username(username)
-    if user and safe_str_cmp(user.password, password):
+    if user and compare_digest(user.password, password):
         return user
 
 def identity(payload):

--- a/section11/resources/user.py
+++ b/section11/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -43,7 +43,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(data['username'])
 
-        if user and safe_str_cmp(user.password, data['password']):
+        if user and compare_digest(user.password, data['password']):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {

--- a/section4/security.py
+++ b/section4/security.py
@@ -1,4 +1,4 @@
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from user import User
 
 users = [
@@ -11,7 +11,7 @@ userid_table = {u.id: u for u in users}
 
 def authenticate(username, password):
     user = username_table.get(username, None)
-    if user and safe_str_cmp(user.password, password):
+    if user and compare_digest(user.password, password):
         return user
 
 def identity(payload):

--- a/section5/security.py
+++ b/section5/security.py
@@ -1,10 +1,10 @@
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from user import User
 
 
 def authenticate(username, password):
     user = User.find_by_username(username)
-    if user and safe_str_cmp(user.password, password):
+    if user and compare_digest(user.password, password):
         return user
 
 

--- a/section6/security.py
+++ b/section6/security.py
@@ -1,10 +1,10 @@
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from models.user import UserModel
 
 
 def authenticate(username, password):
     user = UserModel.find_by_username(username)
-    if user and safe_str_cmp(user.password, password):
+    if user and compare_digest(user.password, password):
         return user
 
 


### PR DESCRIPTION
safe_str_cmp will be removed in Werkzeug 2.1. As suggested to use `hmac.compare_digest` instead.