### PR TITLE
bug(migrate): Remove db.create_all from app creation

### DIFF
--- a/docs/docs/09_flask_migrate/02_add_flask_migrate_to_app/README.md
+++ b/docs/docs/09_flask_migrate/02_add_flask_migrate_to_app/README.md
@@ -36,3 +36,12 @@ api = Api(app)
 with app.app_context():
     db.create_all()
 ```
+
+Since we will be using Flask-Migrate to create our database, we no longer need to tell Flask-SQLAlchemy to do it when we create the app.
+
+Delete these two lines:
+
+```py
+with app.app_context():
+    db.create_all()
+```


### PR DESCRIPTION
This is because we will use Flask-Migrate to create our tables, so we no longer need to do this when we start up the app.