### PR TITLE
bug(docker): fix missing hostname when running flask in docker

### DIFF
--- a/docs/docs/11_deploy_to_render/03_docker_with_gunicorn/README.md
+++ b/docs/docs/11_deploy_to_render/03_docker_with_gunicorn/README.md
@@ -62,9 +62,9 @@ If you use this `Dockerfile`, it doesn't mean you can't run it locally using the
 To run the Docker container locally, you'll have to do this from now on:
 
 ```zsh
-docker run -dp 5000:5000 -w /app -v "$(pwd):/app" teclado-site-flask sh -c "flask run"
+docker run -dp 5000:5000 -w /app -v "$(pwd):/app" teclado-site-flask sh -c "flask run --host 0.0.0.0"
 ```
 
-This is similar to how we've ran the Docker container with our local code as a volume (that's what `-w /app -v "$(pwd):/app"` does), but at the end of the command we're telling the container to run `flask run` instead of the `CMD` line of the `Dockerfile`. That's what `sh -c "flask run"` does!
+This is similar to how we've ran the Docker container with our local code as a volume (that's what `-w /app -v "$(pwd):/app"` does), but at the end of the command we're telling the container to run `flask run --host 0.0.0.0` instead of the `CMD` line of the `Dockerfile`. That's what `sh -c "flask run --host 0.0.0.0"` does!
 
 Now you're ready to commit and push this to your repository and re-deploy to Render.com!


### PR DESCRIPTION
https://rest-apis-flask.teclado.com/docs/deploy_to_render/docker_with_gunicorn/

This lecture was showing this command:

```
docker run -dp 5000:5000 -w /app -v "$(pwd):/app" teclado-site-flask sh -c "flask run"
```

But this should be this:

```
docker run -dp 5000:5000 -w /app -v "$(pwd):/app" teclado-site-flask sh -c "flask run --host 0.0.0.0"
```

Otherwise running the Flask app in development mode locally will work, but it will not be accessible from outside the container's network (i.e. you can't connect to it from the host).