### PR TITLE
Fix bug where top banner text isn't rendered properly in Chrome

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -98,7 +98,7 @@ const config = {
       announcementBar: {
         id: "support_us",
         content:
-          '<span style="font-weight: 600">Unlock all video lessons and support us by <a target="_blank" style="background-image: linear-gradient(90deg, #FF7D82, #50e3c2); background-clip: text; color: transparent; " rel="noopener noreferrer" href="https://go.tecla.do/rest-apis-ebook">buying the course</a>!</span>',
+          '<span style="font-weight: 600">Unlock all video lessons and support us by <a target="_blank" style="background-color: #ff7d82; background-image: linear-gradient(90deg, #FF7D82, #50e3c2); background-clip: text; color: transparent; -webkit-background-clip: text; -moz-background-clip: text; -webkit-text-fill-color: transparent; -moz-text-fill-color: transparent; " rel="noopener noreferrer" href="https://go.tecla.do/rest-apis-ebook">buying the course</a>!</span>',
         backgroundColor: "#1c2023",
         textColor: "#fff",
         isCloseable: false,


### PR DESCRIPTION
It seems Chrome doesn't support the `background-clip` property on its own. Add -webkit and -moz prefixes to background-clip so text renders properly. Also added fallback of `background-color` for browsers that don't support a gradient background image.