### PR TITLE
🐛 fix(Item Update): Fix `ItemUpdateSchema` by adding `store_id`

### DIFF
--- a/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/README.md
+++ b/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/README.md
@@ -30,3 +30,24 @@ def put(self, item_data, item_id):
     return item
     # highlight-end
 ```
+
+Our `ItemUpdateSchema` at the moment looks like this:
+
+```python title="schemas.py"
+class ItemUpdateSchema(Schema):
+    name = fields.Str()
+    price = fields.Float()
+```
+
+But since now our update endpoint may create items, we need to change the schema to optionally accept a `store_id`.
+
+When updating an item, `name` or `price` (or both) may be passed, but when creating an item, `name`, `price`, and `store_id` must be passed.
+
+Update the `ItemUpdateSchema` to this:
+
+```python title="schemas.py"
+class ItemUpdateSchema(Schema):
+    name = fields.Str()
+    price = fields.Float()
+    store_id = fields.Int()
+```


### PR DESCRIPTION
This is not necessary just for updating, but it is necessary for creating items. Since the item update endpoint may update or create items, the `store_id` is added as an optional field to the `ItemUpdateSchema` so that it can be accepted by the API when a client wants to create an item.